### PR TITLE
Fix error when building with Clang

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -131,7 +131,7 @@ bool tree_sitter_rescript_external_scanner_scan(
     const bool* valid_symbols
     ) {
   ScannerState* state = (ScannerState*)payload;
-  const in_string = state->in_quotes || state->in_backticks;
+  const bool in_string = state->in_quotes || state->in_backticks;
 
   if (valid_symbols[TEMPLATE_CHARS]) {
     lexer->result_symbol = TEMPLATE_CHARS;


### PR DESCRIPTION
Building scanner.c with clang fails with this error:

```
src/scanner.c:134:9: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
  const in_string = state->in_quotes || state->in_backticks;
  ~~~~~ ^
  int
1 error generated.
```

This PR fixes the error